### PR TITLE
RFC Interfaces

### DIFF
--- a/ndscan/__init__.py
+++ b/ndscan/__init__.py
@@ -1,0 +1,1 @@
+from . import interfaces

--- a/ndscan/dashboard/argument_editor.py
+++ b/ndscan/dashboard/argument_editor.py
@@ -588,6 +588,7 @@ class ArgumentEditor(QtWidgets.QTreeWidget):
         is_scannable = (self.scan_options is not None) and param.is_scannable
 
         options = OrderedDict([])
+        # TODO: AFAICT this is the only
         if isinstance(param, interfaces.parameters.StringParamInterface):
             options["Fixed"] = StringFixedScanOption
         else:

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -480,14 +480,18 @@ class TopLevelRunner(HasEnvironment):
             name: channel.describe()
             for name, channel in self._analysis_results.items()
         }
+        # import pprint
+        # pprint.pprint(self._scan_desc);assert 0
 
-        for name, value in self._scan_desc.items():
+        for key, value in self._scan_desc.items():
             # Flatten arrays/dictionaries to JSON strings for HDF5 compatibility.
             ds_value = to_metadata_broadcast_type(value)
+            if isinstance(key, interfaces.common.Interface):
+                key = key.encode()
             if ds_value is None:
-                push(name, dump_json(value))
+                push(key, dump_json(value))
             else:
-                push(name, ds_value)
+                push(key, ds_value)
 
     def create_applet(self, title: str, group: str = "ndscan"):
         cmd = [

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -103,7 +103,8 @@ class FragmentScanExperiment(EnvExperiment):
 
         spec, no_axes_mode = self.args.make_scan_spec()
         for ax in spec.axes:
-            fqn = ax.param_schema["fqn"]
+            param = interfaces.utils.decode(ax.param_schema)  # INTERFACES TODO
+            fqn = param.fqn
             param_stores.setdefault(fqn, []).append((ax.path, ax.param_store))
 
         self.fragment.init_params(param_stores)
@@ -207,7 +208,7 @@ class ArgumentInterface(HasEnvironment):
             fqn = axspec["fqn"]
             pathspec = axspec["path"]
 
-            store_type = type_string_to_param(self._schemata[fqn]["type"]).StoreType
+            store_type = type_string_to_param(self._schemata[fqn]).StoreType
             store = store_type((fqn, pathspec),
                                generator.points_for_level(0, random)[0])
             axes.append(ScanAxis(self._schemata[fqn], pathspec, store))
@@ -303,7 +304,8 @@ class TopLevelRunner(HasEnvironment):
 
         axis_indices = {}
         for i, axis in enumerate(self.spec.axes):
-            axis_indices[(axis.param_schema["fqn"], axis.path)] = i
+            param = interfaces.utils.decode(axis.param_schema)  # INTERFACES TODO
+            axis_indices[(param.fqn, axis.path)] = i
         self._annotation_context = AnnotationContext(
             lambda handle: axis_indices[handle._store.identity],
             lambda channel: self._short_child_channel_names[channel],
@@ -343,7 +345,8 @@ class TopLevelRunner(HasEnvironment):
         return self._make_coordinate_dict(), self._make_value_dict()
 
     def _make_coordinate_dict(self):
-        return OrderedDict(((a.param_schema["fqn"], a.path), s.get_all())
+        # INTERFACES TODO
+        return OrderedDict(((interfaces.utils.decode(a.param_schema).fqn, a.path), s.get_all())
                            for a, s in zip(self.spec.axes, self._coordinate_sinks))
 
     def _make_value_dict(self):

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 from .default_analysis import AnnotationContext
 from .fragment import (ExpFragment, Fragment, RestartKernelTransitoryError,
                        TransitoryError)
-from .parameters import ParamStore, type_string_to_param
+from .parameters import ParamStore
 from .result_channels import (AppendingDatasetSink, LastValueSink, ScalarDatasetSink,
                               ResultChannel)
 from .scan_generator import GENERATORS, ScanOptions

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -32,6 +32,7 @@ from .scan_runner import (ScanAxis, ScanRunner, ScanSpec, describe_scan,
 from .utils import dump_json, is_kernel, to_metadata_broadcast_type
 from ..utils import (merge_no_duplicates, NoAxesMode, PARAMS_ARG_KEY, SCHEMA_REVISION,
                      SCHEMA_REVISION_KEY, shorten_to_unambiguous_suffixes, strip_suffix)
+from ..import interfaces
 
 __all__ = [
     "ArgumentInterface", "TopLevelRunner", "make_fragment_scan_exp",
@@ -178,7 +179,9 @@ class ArgumentInterface(HasEnvironment):
         stores = {}
         for fqn, specs in self._params.get("overrides", {}).items():
             try:
-                store_type = type_string_to_param(self._schemata[fqn]["type"]).StoreType
+                # INTERFACES TODO
+                # schemata should still be Interface objects at this stage...
+                store_type = type_string_to_param(self._schemata[fqn]).StoreType
             except KeyError:
                 raise KeyError("Parameter schema not found (likely due to outdated "
                                "argument editor after changes to experiment; "

--- a/ndscan/experiment/entry_point.py
+++ b/ndscan/experiment/entry_point.py
@@ -103,8 +103,7 @@ class FragmentScanExperiment(EnvExperiment):
 
         spec, no_axes_mode = self.args.make_scan_spec()
         for ax in spec.axes:
-            param = interfaces.utils.decode(ax.param_schema)  # INTERFACES TODO
-            fqn = param.fqn
+            fqn = ax.param.fqn
             param_stores.setdefault(fqn, []).append((ax.path, ax.param_store))
 
         self.fragment.init_params(param_stores)
@@ -146,10 +145,10 @@ class ArgumentInterface(HasEnvironment):
         self._fragments = fragments
 
         instances = dict()
-        self._schemata = dict()
+        self._param_tree = dict()
         always_shown_params = []
         for fragment in fragments:
-            fragment._collect_params(instances, self._schemata)
+            fragment._collect_params(instances, self._param_tree)
 
             for handle in fragment.get_always_shown_params():
                 path = handle.owner._stringize_path()
@@ -163,7 +162,7 @@ class ArgumentInterface(HasEnvironment):
 
         desc = {
             "instances": instances,
-            "schemata": self._schemata,
+            "schemata": {fqn: param.encode() for fqn, param in self._param_tree.items()},
             "always_shown": always_shown_params,
             "overrides": {}
         }
@@ -180,11 +179,9 @@ class ArgumentInterface(HasEnvironment):
         stores = {}
         for fqn, specs in self._params.get("overrides", {}).items():
             try:
-                # INTERFACES TODO
-                # schemata should still be Interface objects at this stage...
-                store_type = type_string_to_param(self._schemata[fqn]).StoreType
+                store_type = self._param_tree[fqn].StoreType
             except KeyError:
-                raise KeyError("Parameter schema not found (likely due to outdated "
+                raise KeyError("Parameter not found (likely due to outdated "
                                "argument editor after changes to experiment; "
                                "try Recompute All Arguments)")
 
@@ -208,10 +205,10 @@ class ArgumentInterface(HasEnvironment):
             fqn = axspec["fqn"]
             pathspec = axspec["path"]
 
-            store_type = type_string_to_param(self._schemata[fqn]).StoreType
+            store_type = self._param_tree[fqn].StoreType
             store = store_type((fqn, pathspec),
                                generator.points_for_level(0, random)[0])
-            axes.append(ScanAxis(self._schemata[fqn], pathspec, store))
+            axes.append(ScanAxis(self._param_tree[fqn], pathspec, store))
 
         options = ScanOptions(scan.get("num_repeats", 1),
                               scan.get("randomise_order_globally", False))
@@ -304,8 +301,7 @@ class TopLevelRunner(HasEnvironment):
 
         axis_indices = {}
         for i, axis in enumerate(self.spec.axes):
-            param = interfaces.utils.decode(axis.param_schema)  # INTERFACES TODO
-            axis_indices[(param.fqn, axis.path)] = i
+            axis_indices[(axis.param.fqn, axis.path)] = i
         self._annotation_context = AnnotationContext(
             lambda handle: axis_indices[handle._store.identity],
             lambda channel: self._short_child_channel_names[channel],
@@ -345,8 +341,7 @@ class TopLevelRunner(HasEnvironment):
         return self._make_coordinate_dict(), self._make_value_dict()
 
     def _make_coordinate_dict(self):
-        # INTERFACES TODO
-        return OrderedDict(((interfaces.utils.decode(a.param_schema).fqn, a.path), s.get_all())
+        return OrderedDict(((a.param.fqn, a.path), s.get_all())
                            for a, s in zip(self.spec.axes, self._coordinate_sinks))
 
     def _make_value_dict(self):

--- a/ndscan/experiment/fragment.py
+++ b/ndscan/experiment/fragment.py
@@ -509,7 +509,7 @@ class Fragment(HasEnvironment):
         fqns = []
         for param in self._free_params.values():
             fqn = param.fqn
-            schema = param.describe()
+            schema = param.encode()
             if fqn in schemata:
                 if schemata[fqn] != schema:
                     logger.warn("Mismatch in parameter schema '%s' for '%s'", fqn, path)

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -214,7 +214,36 @@ def resolve_numeric_scale(scale: Optional[float], unit: str) -> float:
         raise KeyError("Unit '{}' is unknown, you must specify "
                        "the scale manually".format(unit))
 
-# @dataclasses.dataclass
+# TODO:
+# Do we want ParamInterfaces to be extensible through custom parameters? A requirement
+# here is that there is no direct access to members of `ParamInterface` subtypes which
+# are not common to all subtypes (to think about: is there a good way of enforcing this
+# commonality through a shared parent class? I've tried to avoid multiple inheritance
+# of dataclasses) the codebase -- everything should be done through common member
+# functions. Need to check to what extend this is already the case / think about whether
+# this is something we could / should do
+# The only place I'm currently aware of where this is not already the case is the
+# argument editor, which special cases string parameters. AFAICT what is really being
+# tested there is whether the parameter is a numeric type which we can scan or something
+# else (e.g. if we add enum/bool types in the future). This can probably be better done
+# by adding a dtype attribute and checking whether that is numeric...
+
+class Param(interfaces.parameters.ParamInterface):
+    # Should the param instances inherit from this? How would we handle this? At present
+    # this is not used anywhere, just me noting down what the common interface is for
+    # my own reference
+    # The only bits that aren't common are the min/max/unit/scale
+    HandleType: ParamHandle
+    StoreType: ParamStore
+    CompilerType: Any  # what should this be?
+    # store the python type here as an attribute? Cleaner way of doing type annotations?
+
+    def eval_default(self, get_dataset: GetDataset) -> Any:
+        raise NotImplementedError
+
+    def make_store(self, identity: Tuple[str, str], value: Any) -> ParamStore:
+        raise NotImplementedError
+
 class FloatParam(interfaces.parameters.FloatParamInterface):
     HandleType: ParamHandle = FloatParamHandle
     StoreType: ParamStore = FloatParamStore

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -17,11 +17,18 @@ from .. import interfaces
 
 __all__ = ["FloatParam", "IntParam", "StringParam"]
 
-
-def type_string_to_param(name: str):
+# TODO: this should not be needed...
+# INTERFACES TODO
+def type_string_to_param(type_string: interfaces.parameters.ParamInterface):
+    param = interfaces.utils.decode(type_string)
     """Resolve a param schema type string to the corresponding Param implementation."""
-    return {"float": FloatParam, "int": IntParam, "string": StringParam}[name]
-
+    if isinstance(param, interfaces.parameters.FloatParamInterface):
+        return FloatParam
+    elif isinstance(param, interfaces.parameters.IntParamInterface):
+        return IntParam
+    elif isinstance(param, interfaces.parameters.StrParam):
+        return StrParam
+    raise NotImplementedError
 
 class InvalidDefaultError(ValueError):
     """Raised when a default value is outside the specified range of valid parameter
@@ -219,7 +226,7 @@ def resolve_numeric_scale(scale: Optional[float], unit: str) -> float:
         raise KeyError("Unit '{}' is unknown, you must specify "
                        "the scale manually".format(unit))
 
-@dataclasses.dataclass
+# @dataclasses.dataclass
 class FloatParam(interfaces.parameters.FloatParamInterface):
     HandleType: ParamHandle = FloatParamHandle
     StoreType: ParamStore = FloatParamStore
@@ -245,7 +252,7 @@ class FloatParam(interfaces.parameters.FloatParamInterface):
         return FloatParamStore(identity, value)
 
 
-@dataclasses.dataclass
+# @dataclasses.dataclass
 class IntParam(interfaces.parameters.IntParamInterface):
     HandleType: ParamHandle = IntParamHandle
     StoreType: ParamStore = IntParamStore
@@ -271,7 +278,7 @@ class IntParam(interfaces.parameters.IntParamInterface):
                 value, self.max))
         return IntParamStore(identity, value)
 
-@dataclasses.dataclass
+# @dataclasses.dataclass
 class StringParam(interfaces.parameters.StringParamInterface):
     HandleType = StringParamHandle
     StoreType = StringParamStore

--- a/ndscan/experiment/parameters.py
+++ b/ndscan/experiment/parameters.py
@@ -17,18 +17,6 @@ from .. import interfaces
 
 __all__ = ["FloatParam", "IntParam", "StringParam"]
 
-# TODO: this should not be needed...
-# INTERFACES TODO
-def type_string_to_param(type_string: interfaces.parameters.ParamInterface):
-    param = interfaces.utils.decode(type_string)
-    """Resolve a param schema type string to the corresponding Param implementation."""
-    if isinstance(param, interfaces.parameters.FloatParamInterface):
-        return FloatParam
-    elif isinstance(param, interfaces.parameters.IntParamInterface):
-        return IntParam
-    elif isinstance(param, interfaces.parameters.StrParam):
-        return StrParam
-    raise NotImplementedError
 
 class InvalidDefaultError(ValueError):
     """Raised when a default value is outside the specified range of valid parameter

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -17,6 +17,7 @@ from .parameters import ParamStore, type_string_to_param
 from .result_channels import ResultChannel, ResultSink
 from .scan_generator import generate_points, ScanGenerator, ScanOptions
 from .utils import is_kernel
+from .. import interfaces
 
 __all__ = [
     "ScanAxis", "ScanSpec", "ScanRunner", "filter_default_analyses", "describe_scan",
@@ -31,9 +32,9 @@ class ScanAxis:
     scan at runtime; i.e. the :class:`.ParamStore` to modify in order to set the
     parameter.
     """
-    def __init__(self, param_schema: Dict[str, Any], path: str,
+    def __init__(self, param: interfaces.parameters.ParamInterface, path: str,
                  param_store: ParamStore):
-        self.param_schema = param_schema
+        self.param = param
         self.path = path
         self.param_store = param_store
 
@@ -379,7 +380,7 @@ def describe_scan(spec: ScanSpec, fragment: ExpFragment,
 
     desc["fragment_fqn"] = fragment.fqn
     axis_specs = [{
-        "param": ax.param_schema,
+        "param": ax.param.encode(),
         "path": ax.path,
     } for ax in spec.axes]
     for ax, gen in zip(axis_specs, spec.generators):

--- a/ndscan/experiment/scan_runner.py
+++ b/ndscan/experiment/scan_runner.py
@@ -13,7 +13,7 @@ from itertools import islice
 from typing import Any, Dict, List, Iterable, Iterator, Tuple
 from .default_analysis import AnnotationContext, DefaultAnalysis
 from .fragment import ExpFragment, TransitoryError, RestartKernelTransitoryError
-from .parameters import ParamStore, type_string_to_param
+from .parameters import ParamStore
 from .result_channels import ResultChannel, ResultSink
 from .scan_generator import generate_points, ScanGenerator, ScanOptions
 from .utils import is_kernel
@@ -159,7 +159,7 @@ class ScanRunner(HasEnvironment):
         self._kscan_param_values_chunk.__func__.__annotations__ = {
             "return":
             TTuple([
-                TList(type_string_to_param(a.param_schema["type"]).CompilerType)
+                TList(a.param.CompilerType)
                 for a in axes
             ])
         }

--- a/ndscan/experiment/subscan.py
+++ b/ndscan/experiment/subscan.py
@@ -219,7 +219,7 @@ def setattr_subscan(owner: Fragment,
         handle = getattr(param_owner, name)
         param, store = param_owner.override_param(name)
 
-        axes[handle] = ScanAxis(param.describe(), "/".join(param_owner._fragment_path),
+        axes[handle] = ScanAxis(param.encode(), "/".join(param_owner._fragment_path),
                                 store)
 
         # We simply generate sequential result channels to be sure we have enough.

--- a/ndscan/experiment/utils.py
+++ b/ndscan/experiment/utils.py
@@ -1,7 +1,7 @@
 import json
 import numpy
 from typing import Any, Iterable, Optional
-
+from .. import interfaces
 
 def path_matches_spec(path: Iterable[str], spec: str) -> bool:
     # TODO: Think about how we want to match.
@@ -20,22 +20,11 @@ def is_kernel(func) -> bool:
     return meta.core_name is not None and not meta.portable
 
 
-class NumpyToVanillaEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, numpy.integer):
-            return int(obj)
-        if isinstance(obj, numpy.floating):
-            return float(obj)
-        if isinstance(obj, numpy.ndarray):
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
-
-
 def dump_json(obj: Any) -> str:
     """Serialise ``obj`` as a JSON string, with NumPy numerical/array types encoded as
     their vanilla Python counterparts.
     """
-    return json.dumps(obj, cls=NumpyToVanillaEncoder)
+    return json.dumps(obj, cls=interfaces.common.Encoder)
 
 
 def to_metadata_broadcast_type(obj: Any) -> Optional[Any]:

--- a/ndscan/interfaces/__init__.py
+++ b/ndscan/interfaces/__init__.py
@@ -1,0 +1,6 @@
+from . import analysis
+from . import annotations
+from . import common
+from . import parameters
+from . import results
+from . import utils

--- a/ndscan/interfaces/analysis.py
+++ b/ndscan/interfaces/analysis.py
@@ -1,0 +1,11 @@
+import enum
+import dataclasses
+from . import common
+
+class AnalysisType(enum.Enum):
+    pass
+
+@dataclasses.dataclass
+class AnalysisInterface(common.Interface):
+    def __post_init__(self):
+        self.interface_type = common.InterfaceType.ANALYSIS

--- a/ndscan/interfaces/annotations.py
+++ b/ndscan/interfaces/annotations.py
@@ -1,0 +1,11 @@
+import enum
+import dataclasses
+from . import common
+
+class AnnotationType(enum.Enum):
+    pass
+
+@dataclasses.dataclass
+class AnnotationInterface(common.Interface):
+    def __post_init__(self):
+        self.interface_type = common.InterfaceType.ANNOTATION

--- a/ndscan/interfaces/annotations.py
+++ b/ndscan/interfaces/annotations.py
@@ -1,11 +1,32 @@
 import enum
 import dataclasses
-from . import common
+from typing import Dict
+from . import common, parameters
 
 class AnnotationType(enum.Enum):
-    pass
+    CUSTOM = "custom"
 
-@dataclasses.dataclass
-class AnnotationInterface(common.Interface):
-    def __post_init__(self):
-        self.interface_type = common.InterfaceType.ANNOTATION
+# @dataclasses.dataclass
+# class AnnotationInterface(common.Interface):
+#     parameters: Dict[str, parameters.ParamInterface]
+#     coordinates: Dict[str, AnnotationDataSource]
+
+#     def __post_init__(self):
+#         self.interface_type = common.InterfaceType.ANNOTATION
+
+#     @staticmethod
+#     def from_dict(data) -> common.Interface:
+#         if not "interface_subtype" in data:
+#             raise ValueError(
+#                 f"Invalid annotation interface schema (missing  annotation subtype): {data}"
+#             )
+
+#         self.parameters = {fqn: parameters.ParameterInterface.decode(desc) for fqn, desc in self.parameters.items()}
+
+#         subtype = AnnotationType(data.pop("interface_subtype"))
+
+#         if subtype == ParamType.CUSTOM:
+#             return common.CustomInterface.from_dict(data)
+
+#         raise ValueError(f"Unrecognised annotation subtype: {subtype}")
+

--- a/ndscan/interfaces/annotations.py
+++ b/ndscan/interfaces/annotations.py
@@ -1,32 +1,57 @@
 import enum
 import dataclasses
-from typing import Dict
+from typing import Dict, Optional, List
 from . import common, parameters
 
 class AnnotationType(enum.Enum):
+    COMPUTED_CURVE = "computed_curve"
     CUSTOM = "custom"
+    LOCATION = "location"
 
 @dataclasses.dataclass
 class AnnotationInterface(common.Interface):
-#     parameters: Dict[str, parameters.ParamInterface]
-#     coordinates: Dict[str, AnnotationDataSource]
+    """ Annotations add content to result data plots to display fits, highlight points
+    of interest in the dataset, etc.
+    """
+    data: Optional[Dict]# = None
 
     def __post_init__(self):
         self.interface_type = common.InterfaceType.ANNOTATION
 
-#     @staticmethod
-#     def from_dict(data) -> common.Interface:
-#         if not "interface_subtype" in data:
-#             raise ValueError(
-#                 f"Invalid annotation interface schema (missing  annotation subtype): {data}"
-#             )
+    @staticmethod
+    def from_dict(data) -> common.Interface:
+        if not "interface_subtype" in data:
+            raise ValueError(
+                f"Invalid annotation interface description (missing annotation subtype): {data}"
+            )
 
-#         self.parameters = {fqn: parameters.ParameterInterface.decode(desc) for fqn, desc in self.parameters.items()}
+        subtype = AnnotationType(data.pop("interface_subtype"))
 
-#         subtype = AnnotationType(data.pop("interface_subtype"))
+        if subtype == AnnotationType.COMPUTED_CURVE:
+            return ComputedCurveAnnotationInteface(**data)
+        elif subtype == AnnotationType.CUSTOM:
+            return common.CustomInterface.from_dict(data)
+        elif subtype == AnnotationType.LOCATION:
+            return LocationAnnotationInteface(**data)
 
-#         if subtype == ParamType.CUSTOM:
-#             return common.CustomInterface.from_dict(data)
+        raise ValueError(f"Unrecognised annotation subtype: {subtype}")
 
-#         raise ValueError(f"Unrecognised annotation subtype: {subtype}")
+@dataclasses.dataclass
+class ComputedCurveAnnotationInteface(AnnotationInterface):
+    function_name: str
+    associated_channels: str
 
+    def __post_init__(self):
+        super().__post_init__()
+        self.interface_subtype = AnnotationType.COMPUTED_CURVE
+
+
+@dataclasses.dataclass
+class LocationAnnotationInteface(AnnotationInterface):
+    associated_channels: List
+    associated_channels: str
+    coordinates: Optional[Dict]# = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.interface_subtype = AnnotationType.LOCATION

--- a/ndscan/interfaces/annotations.py
+++ b/ndscan/interfaces/annotations.py
@@ -6,13 +6,13 @@ from . import common, parameters
 class AnnotationType(enum.Enum):
     CUSTOM = "custom"
 
-# @dataclasses.dataclass
-# class AnnotationInterface(common.Interface):
+@dataclasses.dataclass
+class AnnotationInterface(common.Interface):
 #     parameters: Dict[str, parameters.ParamInterface]
 #     coordinates: Dict[str, AnnotationDataSource]
 
-#     def __post_init__(self):
-#         self.interface_type = common.InterfaceType.ANNOTATION
+    def __post_init__(self):
+        self.interface_type = common.InterfaceType.ANNOTATION
 
 #     @staticmethod
 #     def from_dict(data) -> common.Interface:

--- a/ndscan/interfaces/common.py
+++ b/ndscan/interfaces/common.py
@@ -4,7 +4,7 @@ import enum
 import importlib
 import inspect
 import json
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 # TODO: find instances of "schema" / "schemata" in the code base and see which ones
 # we can replace with more specific types / names
@@ -29,11 +29,12 @@ InterfaceType = TypeVar('T', bound='Parent')
 class InterfaceType(enum.Enum):
     ANALYSIS = "analysis"
     ANNOTATION = "annotation"
+    ANNOTATION_DATA_SOURCE = "annotation_data_source"
     PARAM = "param"
     RESULT = "result"
 
 @dataclasses.dataclass
-class Interface():
+class Interface:
     """ Base class for ndscan interfaces.
 
     Interfaces define the boundary between the experiment and applet sides of ndscan.

--- a/ndscan/interfaces/common.py
+++ b/ndscan/interfaces/common.py
@@ -1,0 +1,118 @@
+import numpy
+import dataclasses
+import enum
+import importlib
+import inspect
+import json
+from typing import Any, TypeVar
+
+class Encoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, numpy.integer):
+            return int(obj)
+        if isinstance(obj, numpy.floating):
+            return float(obj)
+        if isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+        if dataclasses.is_dataclass(obj):
+            return dataclasses.asdict(obj)
+        if isinstance(obj, enum.Enum):
+            return obj.value
+
+InterfaceType = TypeVar('T', bound='Parent')
+
+class InterfaceType(enum.Enum):
+    ANALYSIS = "analysis"
+    ANNOTATION = "annotation"
+    PARAM = "param"
+    RESULT = "result"
+
+@dataclasses.dataclass
+class Interface():
+    """ Base class for ndscan interfaces.
+
+    Interfaces define the boundary between the experiment and applet sides of ndscan.
+    They are convertible to and from string representations (see :meth encode: and
+    :meth decode:), allowing them to be broadcast to applets as part of the scan
+    metadata dataset and stored in experiments' HD5 files.
+
+    Interfaces provide the subset of functionality which is shared between the
+    experiment and applet side code. The specialised separately on the experiment/applet
+    sides to add additional functionality which is only meaningful on one side.
+
+    ndscan interfaces are extensible: users may define their own interface subtypes,
+    which will be dynamically loaded on the applet side. See :class CustomInterface: for
+    details.
+
+    Attributes:
+        interface_type: type of interface (see :class InterfaceType:)
+    """
+
+    interface_type: InterfaceType = dataclasses.field(init=False)
+    interface_subtype: enum.Enum = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        """ Implementations must set interface_type """
+        raise NotImplementedError
+
+    def encode(self):
+        return json.dumps(self, cls=Encoder)
+
+    @classmethod
+    def from_dict(cls, data) -> InterfaceType:
+        return cls(data)
+
+    @staticmethod
+    def get_type() -> enum.Enum:
+        raise NotImplementedError
+
+def import_class(module_name: str, class_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        raise ValueError(f'Cannot import module "{module_name}"')
+
+    module_classes = [
+        name for name, obj in inspect.getmembers(module) if inspect.isclass(obj)
+    ]
+
+    if class_name not in module_classes:
+        raise ValueError(f'Class "{class_name}" not in module "{module_name}"')
+
+    cls = getattr(module, class_name)
+    return cls
+
+def make_custom_interface(interface_class: Interface, applet_class: Interface):
+    """ Takes in an Interface class and its corresponding applet-side subclass and
+    returns a CustomInterface class. """
+
+    @dataclasses.dataclass
+    class CustomInterfaceImpl(interface_class):
+
+        applet_module: str = dataclasses.field(init=False)
+        applet_class: str = dataclasses.field(init=False)
+
+        def __post_init__(self):
+            super().__post_init__()
+            self.applet_module = applet_class.__module__
+            self.applet_class = applet_class.__name__
+            self.interface_subtype = interface_class.get_type().CUSTOM
+
+        @classmethod
+        def from_dict(data):
+            applet_module = data.pop("applet_module")
+            applet_class = data.pop("applet_class")
+            return import_class(applet_module, applet_class)(**data)
+
+    return CustomInterfaceImpl
+
+class CustomInterface(Interface):
+    applet_module: str = dataclasses.field(init=False)
+    applet_class: str = dataclasses.field(init=False)
+
+    @staticmethod
+    def from_dict(data):
+        applet_module = data.pop("applet_module")
+        applet_class = data.pop("applet_class")
+        return import_class(applet_module, applet_class)(**data)
+

--- a/ndscan/interfaces/common.py
+++ b/ndscan/interfaces/common.py
@@ -6,6 +6,8 @@ import inspect
 import json
 from typing import Any, TypeVar
 
+# TODO: find instances of "schema" / "schemata" in the code base and see which ones
+# we can replace with more specific types / names
 class Encoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, numpy.integer):

--- a/ndscan/interfaces/parameters.py
+++ b/ndscan/interfaces/parameters.py
@@ -1,5 +1,6 @@
 import enum
 import dataclasses
+from typing import Dict, Optional, Union
 from . import common
 
 class ParamType(enum.Enum):
@@ -11,10 +12,10 @@ class ParamType(enum.Enum):
 @dataclasses.dataclass
 class ParamInterface(common.Interface):
     interface_subtype: ParamType = dataclasses.field(init=False)
+    # TODO: can we make is_scannable an attr here? How to handle defaults
 
-    fqn: str
-    description: str
-    is_scannable: bool
+    fqn: str = dataclasses.field()
+    description: str = dataclasses.field()
 
     def __post_init__(self):
         self.interface_type = common.InterfaceType.PARAM
@@ -46,11 +47,12 @@ class ParamInterface(common.Interface):
 @dataclasses.dataclass
 class FloatParamInterface(ParamInterface):
     default: Union[str, float]
-    min: Optional[float] = dataclasses.field(default=None, kw_only=True)
-    max: Optional[float] = dataclasses.field(default=None, kw_only=True)
-    unit: str = dataclasses.field(default="", kw_only=True)
-    scale: Optional[float] = dataclasses.field(default=None, kw_only=True)
-    step: Optional[float] = dataclasses.field(default=None, kw_only=True)
+    min: Optional[float] = dataclasses.field(default=None)#, kw_only=True)
+    max: Optional[float] = dataclasses.field(default=None)#, kw_only=True)
+    unit: str = dataclasses.field(default="")#, kw_only=True)
+    scale: Optional[float] = dataclasses.field(default=None)#, kw_only=True)
+    step: Optional[float] = dataclasses.field(default=None)#, kw_only=True)
+    is_scannable: bool = dataclasses.field(default=True)
 
     def __post_init__(self):
         super().__post_init__()
@@ -59,18 +61,20 @@ class FloatParamInterface(ParamInterface):
 @dataclasses.dataclass
 class IntParamInterface(ParamInterface):
     default: Union[str, int]
-    min: Optional[int] = dataclasses.field(default=None, kw_only=True)
-    max: Optional[int] = dataclasses.field(default=None, kw_only=True)
-    unit: str = dataclasses.field(default="", kw_only=True)
-    scale: Optional[int] = dataclasses.field(default=None, kw_only=True)
+    min: Optional[int] = dataclasses.field(default=None)#, kw_only=True)
+    max: Optional[int] = dataclasses.field(default=None)#, kw_only=True)
+    unit: str = dataclasses.field(default="")#, kw_only=True)
+    scale: Optional[int] = dataclasses.field(default=None)#, kw_only=True)
+    is_scannable: bool = dataclasses.field(default=True)
 
     def __post_init__(self):
         super().__post_init__()
         self.interface_subtype = ParamType.INT
 
 @dataclasses.dataclass
-class StringParam(ParamInterface):
+class StringParamInterface(ParamInterface):
     default: str
+    is_scannable: bool = dataclasses.field(default=True)
 
     def __post_init__(self):
         super().__post_init__()

--- a/ndscan/interfaces/parameters.py
+++ b/ndscan/interfaces/parameters.py
@@ -1,6 +1,6 @@
 import enum
 import dataclasses
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 from . import common
 
 class ParamType(enum.Enum):

--- a/ndscan/interfaces/parameters.py
+++ b/ndscan/interfaces/parameters.py
@@ -1,0 +1,75 @@
+import enum
+import dataclasses
+from . import common
+
+class ParamType(enum.Enum):
+    FLOAT = "float_param"
+    INT = "int_param"
+    STR = "str_param"
+    CUSTOM = "custom_param"
+
+@dataclasses.dataclass
+class ParamInterface(common.Interface):
+    interface_subtype: ParamType = dataclasses.field(init=False)
+
+    fqn: str
+    description: str
+    is_scannable: bool
+    default: str
+
+    def __post_init__(self):
+        self.interface_type = common.InterfaceType.PARAM
+
+    @staticmethod
+    def from_dict(data) -> common.Interface:
+        if not "interface_subtype" in data:
+            raise ValueError(
+                f"Invalid parameter interface schema (missing parameter type): {data}"
+            )
+
+        subtype = ParamType(data.pop("interface_subtype"))
+
+        if subtype == ParamType.FLOAT:
+            return FloatParamInterface(**data)
+        elif subtype == ParamType.INT:
+            return IntParamInterface(**data)
+        elif subtype == ParamType.STR:
+            return StrParamInterface(**data)
+        elif subtype == ParamType.CUSTOM:
+            return common.CustomInterface.from_dict(data)
+
+        raise ValueError(f"Unrecognised parameter type: {subtype}")
+
+    @staticmethod
+    def get_type() -> enum.Enum:
+        return ParamType
+
+@dataclasses.dataclass
+class FloatParamInterface(ParamInterface):
+    param_min: float
+    param_max: float
+    param_unit: str  # CHECK type
+    scale: float
+    step: float
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.interface_subtype = ParamType.FLOAT
+
+@dataclasses.dataclass
+class IntParamInterface(ParamInterface):
+    param_min: int
+    param_max: int
+    param_unit: str  # CHECK type
+    scale: str  # CHECK type
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.interface_subtype = ParamType.INT
+
+@dataclasses.dataclass
+class StringParam(ParamInterface):
+    def __post_init__(self):
+        super().__post_init__()
+        self.interface_subtype = ParamType.STR
+

--- a/ndscan/interfaces/parameters.py
+++ b/ndscan/interfaces/parameters.py
@@ -15,7 +15,6 @@ class ParamInterface(common.Interface):
     fqn: str
     description: str
     is_scannable: bool
-    default: str
 
     def __post_init__(self):
         self.interface_type = common.InterfaceType.PARAM
@@ -46,11 +45,12 @@ class ParamInterface(common.Interface):
 
 @dataclasses.dataclass
 class FloatParamInterface(ParamInterface):
-    param_min: float
-    param_max: float
-    param_unit: str  # CHECK type
-    scale: float
-    step: float
+    default: Union[str, float]
+    min: Optional[float] = dataclasses.field(default=None, kw_only=True)
+    max: Optional[float] = dataclasses.field(default=None, kw_only=True)
+    unit: str = dataclasses.field(default="", kw_only=True)
+    scale: Optional[float] = dataclasses.field(default=None, kw_only=True)
+    step: Optional[float] = dataclasses.field(default=None, kw_only=True)
 
     def __post_init__(self):
         super().__post_init__()
@@ -58,10 +58,11 @@ class FloatParamInterface(ParamInterface):
 
 @dataclasses.dataclass
 class IntParamInterface(ParamInterface):
-    param_min: int
-    param_max: int
-    param_unit: str  # CHECK type
-    scale: str  # CHECK type
+    default: Union[str, int]
+    min: Optional[int] = dataclasses.field(default=None, kw_only=True)
+    max: Optional[int] = dataclasses.field(default=None, kw_only=True)
+    unit: str = dataclasses.field(default="", kw_only=True)
+    scale: Optional[int] = dataclasses.field(default=None, kw_only=True)
 
     def __post_init__(self):
         super().__post_init__()
@@ -69,6 +70,8 @@ class IntParamInterface(ParamInterface):
 
 @dataclasses.dataclass
 class StringParam(ParamInterface):
+    default: str
+
     def __post_init__(self):
         super().__post_init__()
         self.interface_subtype = ParamType.STR

--- a/ndscan/interfaces/parameters.py
+++ b/ndscan/interfaces/parameters.py
@@ -16,6 +16,7 @@ class ParamInterface(common.Interface):
 
     fqn: str = dataclasses.field()
     description: str = dataclasses.field()
+    default: Any
 
     def __post_init__(self):
         self.interface_type = common.InterfaceType.PARAM
@@ -74,6 +75,7 @@ class IntParamInterface(ParamInterface):
 @dataclasses.dataclass
 class StringParamInterface(ParamInterface):
     default: str
+    # should be in parent class but for issue around ordering of default params
     is_scannable: bool = dataclasses.field(default=True)
 
     def __post_init__(self):

--- a/ndscan/interfaces/results.py
+++ b/ndscan/interfaces/results.py
@@ -1,0 +1,11 @@
+import enum
+import dataclasses
+from . import common
+
+class ResultType(enum.Enum):
+    pass
+
+@dataclasses.dataclass
+class ResultInterface(common.Interface):
+    def __post_init__(self):
+        self.interface_type = common.InterfaceType.RESULT

--- a/ndscan/interfaces/utils.py
+++ b/ndscan/interfaces/utils.py
@@ -21,6 +21,8 @@ def decode(data) -> common.Interface:
         cls = parameters.ParamInterface
     elif interface_type == common.InterfaceType.RESULT:
         cls = result.ResultInterface
+    elif interface_type == common.InterfaceType.ANNOTATION_DATA_SOURCE:
+        cls = annotations.AnnotationDataSourceInterface
     else:
         raise ValueError(f"Unrecognised interface type: {interface_type}")
 

--- a/ndscan/interfaces/utils.py
+++ b/ndscan/interfaces/utils.py
@@ -1,0 +1,71 @@
+import dataclasses
+import json
+from . import analysis, annotations, common, parameters, results
+
+def decode(data) -> common.Interface:
+    data_dict = json.loads(data)
+
+    if not "interface_type" in data_dict:
+        raise ValueError(f"Invalid interface schema (missing interface type): {data}")
+
+    interface_type = common.InterfaceType(data_dict.pop("interface_type"))
+
+    if interface_type == common.InterfaceType.ANALYSIS:
+        cls = analysis.AnalysisInterface
+    elif interface_type == common.InterfaceType.ANNOTATION:
+        cls = annotations.AnnotationInterface
+    elif interface_type == common.InterfaceType.PARAM:
+        cls = parameters.ParamInterface
+    elif interface_type == common.InterfaceType.RESULT:
+        cls = result.ResultInterface
+    else:
+        raise ValueError(f"Unrecognised interface type: {interface_type}")
+
+    return cls.from_dict(data_dict)
+
+# TODO: make these into unit tests!
+def test_encode_decode():
+    # todo: loop through all classes and fill out fields automatically
+    iface = parameters.IntParamInterface(
+        fqn="fqn",
+        description="description",
+        is_scannable=True,
+        default="0",
+        param_min=100,
+        param_max=0,
+        param_unit=1,
+        scale="scale"
+    )
+    desc = iface.encode()
+    decoded = decode(desc)
+    assert decoded == iface
+
+@dataclasses.dataclass
+class FooParameterInterface(parameters.ParamInterface):
+    foo: str
+
+class FooParameterExp(FooParameterInterface):
+    pass
+
+class FooParameterApplet(FooParameterInterface):
+    def __post_init__(self):
+        print("applet init...")
+
+def test_custom_encode_decode():
+    iface_cls = common.make_custom_interface(FooParameterInterface,
+                                             FooParameterApplet
+                                            )
+    iface = iface_cls(fqn="fqn",
+                      description="a custom interface!",
+                      is_scannable=False,
+                      default="default",
+                      foo="foo!"
+                     )
+
+    desc = iface.encode()
+    applet_iface = decode(desc)
+if __name__ == "__main__":
+    test_encode_decode()
+    test_custom_encode_decode()
+
+

--- a/ndscan/interfaces/utils.py
+++ b/ndscan/interfaces/utils.py
@@ -3,7 +3,10 @@ import json
 from . import analysis, annotations, common, parameters, results
 
 def decode(data) -> common.Interface:
-    data_dict = json.loads(data)
+    if isinstance(data, dict):
+        data_dict = data
+    else:
+        data_dict = json.loads(data)
 
     if not "interface_type" in data_dict:
         raise ValueError(f"Invalid interface schema (missing interface type): {data}")

--- a/ndscan/plots/annotation_items.py
+++ b/ndscan/plots/annotation_items.py
@@ -3,6 +3,7 @@
 This includes, for instance, fit curves and lines indicating fit results.
 """
 
+# INTERFACES TODO: rename to annotations?
 import logging
 import numpy
 from oitg import uncertainty_to_string
@@ -56,6 +57,7 @@ class ComputedCurveItem(AnnotationItem):
                                                     rateLimit=30)
 
         for source in self._data_sources.values():
+            print("SOURCE", source)
             source.changed.connect(self.redraw_limiter.signalReceived)
 
         self.redraw_limiter.signalReceived()

--- a/ndscan/plots/annotations.py
+++ b/ndscan/plots/annotations.py
@@ -1,0 +1,107 @@
+import dataclasses
+from ..interfaces.annotations import (AnnotationInterface,
+                                      ComputedCurveAnnotationInterface,
+                                      LocationAnnotationInterface,
+                                      AnnotationType)
+from .. import interfaces
+
+# INTERFACES TODO: this class not currently used...
+@dataclasses.dataclass
+class Annotation(AnnotationInterface):
+
+    def get_item(self):
+        return []
+
+@dataclasses.dataclass
+class ComputedCurveAnnotation(ComputedCurveAnnotationInterface):
+    def get_item(self, channel_ref_to_series_idx, make_curve_item, series, param):
+        from ndscan.plots import annotation_items  # TODO: fix circular import!
+
+        function_name = self.function_name
+        if not annotation_items.ComputedCurveItem.is_function_supported(function_name):
+            raise ValueError(f"Unsupported function: {function_name}")
+
+        associated_series_idx = max(
+            channel_ref_to_series_idx(chan)
+            for chan in self.associated_channels
+        )
+
+        x_limits = [param.min, param.max]
+        curve = make_curve_item(associated_series_idx)
+        vb = series[associated_series_idx].view_box
+
+        item = annotation_items.ComputedCurveItem(function_name, self.data, vb, curve, x_limits)
+        return item
+
+@dataclasses.dataclass
+class LocationAnnotation(LocationAnnotationInterface):
+    def get_item(self, channel_ref_to_series_idx, make_curve_item, series, param):
+        return []
+
+            # if a.kind == "location":
+            #     if set(a.coordinates.keys()) == set(["axis_0"]):
+            #         associated_series_idx = max(
+            #             channel_ref_to_series_idx(chan)
+            #             for chan in a.parameters.get("associated_channels", [None]))
+
+            #         color = FIT_COLORS[associated_series_idx % len(FIT_COLORS)]
+            #         vb = self.series[associated_series_idx].view_box
+            #         line = VLineItem(a.coordinates["axis_0"],
+            #                          a.data.get("axis_0_error", None), vb, color,
+            #                          self.x_data_to_display_scale, self.x_unit_suffix)
+            #         self.annotation_items.append(line)
+            #         continue
+
+# if a.kind == "curve":
+#     associated_series_idx = None
+#     for series_idx, series in enumerate(self.series):
+#         match_coords = set(["axis_0", "channel_" + series.data_name])
+#         if set(a.coordinates.keys()) == match_coords:
+#             associated_series_idx = series_idx
+#             break
+#     if associated_series_idx is not None:
+#         curve = make_curve_item(associated_series_idx)
+#         series = self.series[associated_series_idx]
+#         vb = series.view_box
+#         item = CurveItem(a.coordinates["axis_0"],
+#                          a.coordinates["channel_" + series.data_name], vb,
+#                          curve)
+#         self.annotation_items.append(item)
+#         continue
+
+#     function_name = a.parameters.get("function_name", None)
+#     if ComputedCurveItem.is_function_supported(function_name):
+#         associated_series_idx = max(
+#             channel_ref_to_series_idx(chan)
+#             for chan in a.parameters.get("associated_channels", [None]))
+
+#         x_limits = [self.x_param_spec.get(n, None) for n in ("min", "max")]
+#         curve = make_curve_item(associated_series_idx)
+#         vb = self.series[associated_series_idx].view_box
+#         item = ComputedCurveItem(function_name, a.data, vb, curve, x_limits)
+#         self.annotation_items.append(item)
+#         continue
+
+# Promoting casting to subtypes of dataclasses seems messy...or am I missing something?
+def interface_to_analysis(interface):
+    iface_desc = interface.to_dict()
+
+    interface_type = iface_desc.pop("interface_type")
+    if interface_type != interfaces.common.InterfaceType.ANNOTATION:
+        raise ValueError(f"Invalid interface type: {interface_type}")
+
+    if not "interface_subtype" in iface_desc:
+        raise ValueError(
+            f"Invalid annotation interface description (missing annotation subtype): {iface_desc}"
+        )
+
+    subtype = AnnotationType(iface_desc.pop("interface_subtype"))
+
+    if subtype == AnnotationType.COMPUTED_CURVE:
+        return ComputedCurveAnnotation(**iface_desc)
+    elif subtype == AnnotationType.CUSTOM:
+        return interface
+    elif subtype == AnnotationType.LOCATION:
+        return LocationAnnotation(**iface_desc)
+
+    raise ValueError(f"Unrecognised annotation subtype: {subtype}")

--- a/ndscan/plots/image_2d.py
+++ b/ndscan/plots/image_2d.py
@@ -1,4 +1,5 @@
 """Pseudocolor 2D plot for equidistant data."""
+# INTERFACES TODO (parameters)
 
 from itertools import chain, repeat
 import logging

--- a/ndscan/plots/model/subscriber.py
+++ b/ndscan/plots/model/subscriber.py
@@ -177,7 +177,7 @@ class SubscriberScanModel(ScanModel):
 
         annotation_json = data.get(self._prefix + "annotations", (False, None))[1]
         if annotation_json != self._annotation_json:
-            self._set_annotation_schemata(json.loads(annotation_json))
+            self._decode_annotations(json.loads(annotation_json))
             self._annotation_json = annotation_json
 
         analysis_results_json = data.get(self._prefix + "analysis_results",

--- a/ndscan/utils.py
+++ b/ndscan/utils.py
@@ -103,11 +103,11 @@ class GetDataset(Protocol):
         ...
 
 
-def eval_param_default(value: str, get_dataset: GetDataset) -> Any:
+def eval_param_default(value: Any, get_dataset: GetDataset) -> Any:
     from artiq.language import units
     env = {name: getattr(units, name) for name in units.__all__}
     env.update({"dataset": get_dataset})
-    return eval(value, env)
+    return eval(str(value), env)
 
 
 def merge_no_duplicates(target: dict, source: dict, kind: str = "entries") -> None:

--- a/test/test_experiment_parameters.py
+++ b/test/test_experiment_parameters.py
@@ -3,10 +3,10 @@ from ndscan.experiment.parameters import FloatParam, IntParam
 
 
 class FloatParamCase(unittest.TestCase):
-    def test_describe(self):
+    def test_encode(self):
         param = FloatParam("foo", "bar", 1.0, min=0.0, max=2.0, unit="baz", scale=1.0)
         self.assertEqual(
-            param.describe(), {
+            param.encode(), {
                 "fqn": "foo",
                 "description": "bar",
                 "default": "1.0",
@@ -23,10 +23,10 @@ class FloatParamCase(unittest.TestCase):
 
 
 class IntParamCase(unittest.TestCase):
-    def test_describe(self):
+    def test_encode(self):
         param = IntParam("foo", "bar", 0, min=-1, max=1, unit="baz", scale=1)
         self.assertEqual(
-            param.describe(), {
+            param.encode(), {
                 "fqn": "foo",
                 "description": "bar",
                 "default": "0",


### PR DESCRIPTION
RFC working towards a solution to https://github.com/OxfordIonTrapGroup/ndscan/issues/308

I want to accomplish two things here. Firstly, replacing the "schema" dictionaries with more concrete types. Secondly, providing a framework for allowing custom applet side code to be used.

The idea I'm playing with is to have `Interface` classes, which define the basic structure which is common to both experiment and applet side code. For each subclass there will generally be both an `ndscan.experiments` specialisation, which adds the experiment-specific code, and an `ndscan.plots` specialisation which adds the applet-side code.

Extending the experiment-side code with custom subtypes is generally easy, since one can pass objects in to function calls. On the applet side we need to tell `ndscan` how to deserialise the information broadcast from the master to create an object.

This is still just a skeletal sketch of what a design could look like. In particular, I haven't implemented any of the experiment-applet side code or integrated it with the rest of ndscan. I wanted to push something out to have a basis for a discussion about general directions.

TODO: rebase after merging https://github.com/OxIonics/upstream-ndscan/pull/2